### PR TITLE
Add some configurable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Cosmic rays hit computer RAM all the time. If your RAM is not ECC protected, it 
 
 Bit flips manifest in many ways - computer clusters suddenly dying, data silently being corrupted, and even [squatting on domain names that are a bit adjacent](http://dinaburg.org/bitsquatting.html).
 
-To start your very own bit flip detector, simply run `make` and `./bitflip`. The source code has no dependencies and is worryingly simple.
+To start your very own bit flip detector, simply run `make` and `./bitflip`. The source code has no dependencies and is worryingly simple. Optional arguments are `-g <gigabytes>` to specify the size of the memory allocation and `-d <seconds>` to specify the delay interval between tests/checks.
 
 Detection is via allocating a slice of zeroed memory, in our case a gigabyte, and then once per minute going through to ensure they're actually all zeroes. Magic!
 

--- a/bitflip.c
+++ b/bitflip.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,14 +14,88 @@ char *timestamp()
   return asctime(localtime(&ltime));
 }
 
-int main() {
-  size_t bytes = 1073741824;
+#define DEFAULT_CONF_GB 1
+#define DEFAULT_CONF_DELAY 30
+
+typedef struct
+{
+  int gb;
+  int delay;
+  bool force;
+} run_config;
+
+bool parse_args(int argc, char** argv, run_config* conf)
+{
+  for (int i = 0; i < argc;)
+  {
+    if (0 == strcmp("-g", argv[i]))
+    {
+      if (i + 1 >= argc)
+      {
+        return false;
+      }
+
+      conf->gb = strtol(argv[i + 1], NULL, 10);
+      if (conf->gb < 1 || conf->gb > 1024 * 1024 /* 1 petabyte */)
+      {
+        return false;
+      }
+      i += 2;
+    }
+    else if (0 == strcmp("-d", argv[i]))
+    {
+      if (i + 1 >= argc)
+      {
+        return false;
+      }
+
+      conf->delay = strtol(argv[i + 1], NULL, 10);
+      if (conf->delay < 1 || conf->delay > 365 * 86400 /* 1 year */)
+      {
+        return false;
+      }
+      i += 2;
+    }
+    else if (0 == strcmp("-f", argv[i]))
+    {
+      conf->force = true;
+      i++;
+    }
+    else
+    {
+      // Unknown option
+      return false;
+    }
+  }
+
+  return true;
+}
+
+int main(int argc, char** argv) {
+  run_config conf = { .gb = DEFAULT_CONF_GB, .delay = DEFAULT_CONF_DELAY, .force = false };
+  if (!parse_args(argc - 1, argv + 1, &conf))
+  {
+    printf("%s usage:\n", argv[0]);
+    printf("\t-g <gigabytes>: memory allocation size\n");
+    printf("\t-d <seconds>: delay interval between checks\n");
+    printf("\t-f: force acceptance of questionable parameters\n");
+    return 1;
+  }
+
+  if (!conf.force && (conf.delay < 5 || conf.gb > 8))
+  {
+    printf("Requested more than 8 GB allocation or less than 5 seconds delay!\n");
+    printf("Use -f to force if you are really sure this is what you want!\n");
+    return 1;
+  }
+
+  size_t bytes = conf.gb * 1073741824UL;
   unsigned int tests = 0;
-  unsigned char total = 0;
+  unsigned int total = 0;
 
   printf("=== Bitflipped ===\n");
   printf("==================\n");
-  printf("Allocating a gigabyte ...\n");
+  printf("Allocating %d GB...\n", conf.gb);
   unsigned char *buffer = (unsigned char *)calloc(bytes, 1);
 
   // Ensure the buffer is actually resident in RAM
@@ -32,7 +107,7 @@ int main() {
   fflush(stdout);
   while (total == 0) {
     // We aren't going to miss a bitflip by being slow
-    sleep(30);
+    sleep(conf.delay);
 
     // Naively walk through and tally all zero bytes
     for (size_t i = 0; i < bytes; ++i) {
@@ -40,7 +115,7 @@ int main() {
     }
 
     // Keep the user sane that it isn't frozen :)
-    fprintf(stderr, "\rTest run #%d", tests);
+    fprintf(stderr, "\rTest run #%d (every %ds)", tests, conf.delay);
     ++tests;
   }
 


### PR DESCRIPTION
With this change, users can now specify a custom allocation size (in gigabytes) and a custom check/test delay interval (in seconds).